### PR TITLE
Add support for NixOS, and other irregularly pathed distros

### DIFF
--- a/src/theme/paths.rs
+++ b/src/theme/paths.rs
@@ -28,7 +28,6 @@ fn icon_theme_base_paths() -> Vec<PathBuf> {
     ];
 
     dirs.extend(xdg_data_dirs_sys_vec);
-    println!("{dirs:#?}");
     dirs.into_iter().filter(|p| p.exists()).collect()
 }
 

--- a/src/theme/paths.rs
+++ b/src/theme/paths.rs
@@ -14,16 +14,22 @@ fn icon_theme_base_paths() -> Vec<PathBuf> {
     let usr_data_dir = data_dir().expect("No $XDG_DATA_DIR").join("icons");
     let xdg_data_dirs_local = PathBuf::from("/usr/local/share/").join("icons");
     let xdg_data_dirs = PathBuf::from("/usr/share/").join("icons");
+    let mut xdg_data_dirs_sys_vec: Vec<PathBuf> = vec![];
+    let xdg_data_dirs_sys_raw = std::env::var("XDG_DATA_DIRS").expect("No $XDG_DATA_DIRS");
+    for i in xdg_data_dirs_sys_raw.split(':') {
+        xdg_data_dirs_sys_vec.push(PathBuf::from(i).join("icons"));
+    }
 
-    [
+    let mut dirs = vec![
         home_icon_dir,
         usr_data_dir,
         xdg_data_dirs_local,
         xdg_data_dirs,
-    ]
-    .into_iter()
-    .filter(|p| p.exists())
-    .collect()
+    ];
+
+    dirs.extend(xdg_data_dirs_sys_vec);
+    println!("{dirs:#?}");
+    dirs.into_iter().filter(|p| p.exists()).collect()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The variable naming is weird, but it works :)

Better explantation, distros like nix that dont use the `/usr/...`, or applications that store their stuff elsewhere will add to the `XDG_DATA_DIRS` env variable, so not in the standard locations. This PR will add support for that env var.