### PR TITLE
fix: merge themes from multiple locations

### DIFF
--- a/src/theme/parse.rs
+++ b/src/theme/parse.rs
@@ -88,11 +88,18 @@ mod test {
 
     #[test]
     fn should_get_theme_parents() {
-        let theme = THEMES.get("Arc").unwrap();
-        let parents = theme.inherits();
+        for theme in THEMES.get("Arc").unwrap() {
+            let parents = theme.inherits();
 
-        assert_that!(parents).does_not_contain("hicolor");
+            assert_that!(parents).does_not_contain("hicolor");
 
-        assert_that!(parents).is_equal_to(vec!["Moka", "Faba", "elementary", "Adwaita", "gnome"]);
+            assert_that!(parents).is_equal_to(vec![
+                "Moka",
+                "Faba",
+                "elementary",
+                "Adwaita",
+                "gnome",
+            ]);
+        }
     }
 }

--- a/src/theme/paths.rs
+++ b/src/theme/paths.rs
@@ -61,7 +61,7 @@ mod test {
     #[test]
     fn should_read_theme_index() -> Result<()> {
         let themes = get_all_themes()?;
-        let themes: Vec<&Theme> = themes.values().collect();
+        let themes: Vec<&Theme> = themes.values().flatten().collect();
         assert_that!(themes).is_not_empty();
         Ok(())
     }


### PR DESCRIPTION
Loads the same theme from multiple locations and uses all of them for a given lookup.

Should not change any public api and be safe to be released as a bugfix version. :)

Fixes #7 