### PR TITLE
Add option to override theme search path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0.57"
 linicon = "2.3.0"
 gtk4 = "0.4.7"
 criterion = "0.3.5"
+tempfile = "3.6.0"
 
 [[bench]]
 name = "simple_lookup"


### PR DESCRIPTION
Thanks for creating freedesktop-icons! This crate, as well as your other project, onagre, have been inspirations for my own rust-based launcher program. 

Normally, freedesktop_icon uses environment variables to determine which folders to search for themes. This is sufficient for most usage by applications, but for testing purposes it can be useful to build mock themes in temporary directories, hence the addition of `with_xdg_dir`

For example, currently the crate tests for freedektop-icons assumes the environment it is running in has certain themes and applications installed already. By adding this mocking function the groundwork is laid for rewriting these tests to be independent of their environment. 