### PR TITLE
Icon lookup fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,16 @@ impl<'a> LookupBuilder<'a> {
                     }
                     None
                 })
+                .or_else(|| {
+                    for theme_base_dir in BASE_PATHS.iter() {
+                        if let Some(icon) =
+                            try_build_icon_path(self.name, theme_base_dir, self.force_svg)
+                        {
+                            return Some(icon);
+                        }
+                    }
+                    None
+                })
                 .or_else(|| try_build_icon_path(self.name, "/usr/share/pixmaps", self.force_svg))
                 .or_else(|| {
                     let p = PathBuf::from(&self.name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl<'a> LookupBuilder<'a> {
                 .or_else(|| try_build_icon_path(self.name, "/usr/share/pixmaps", self.force_svg))
                 .or_else(|| {
                     let p = PathBuf::from(&self.name);
-                    if let (Some(name), Some(parent)) = (p.file_name(), p.parent()) {
+                    if let (Some(name), Some(parent)) = (p.file_stem(), p.parent()) {
                         try_build_icon_path(&name.to_string_lossy(), parent, self.force_svg)
                     } else {
                         None


### PR DESCRIPTION
Two small fixes for some icon lookup edge-cases.

1. According to the [Freedesktop Icon Specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#icon_lookup)'s example code, it is valid to have icon files directly in the base-paths not belonging to a theme.

```
LookupFallbackIcon (iconname) {
  for each directory in $(basename list) {
    for extension in ("png", "svg", "xpm") {
      if exists directory/iconname.extension
        return directory/iconname.extension
    }
  }
  return none
}
```

This is fixed by https://github.com/oknozor/freedesktop-icons/commit/2f7f1e6122c1352ef2f12d984c1ae134c5657867

2. The last fallback for desktop-entries providing full file paths incorrectly split up the path, resulting in testing for duplicate extensions for the file name (e.g. `.png.png`).

`try_build_icon_path` adds the extension again, so lets just use the `file_stem` instead of `file_name` to fix this.

Fixed by https://github.com/oknozor/freedesktop-icons/commit/5fcf733a9b8c49afa19c7753e85a86f62c9294f9