### PR TITLE
fix: use the first index.theme from base directories

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!     .find();
 //! # }
 //! ```
-use theme::{Theme, BASE_PATHS};
+use theme::BASE_PATHS;
 
 use crate::cache::{CacheEntry, CACHE};
 use crate::theme::{try_build_icon_path, THEMES};
@@ -257,15 +257,11 @@ impl<'a> LookupBuilder<'a> {
                     })
                 })
                 .or_else(|| {
-                    for theme_base_dir in BASE_PATHS.iter() {
-                        let theme = Theme::from_path(theme_base_dir.join("hicolor"));
-                        if let Some(icon) = theme.and_then(|theme| {
+                    THEMES.get("hicolor").and_then(|icon_themes| {
+                        icon_themes.iter().find_map(|theme| {
                             theme.try_get_icon(self.name, self.size, self.scale, self.force_svg)
-                        }) {
-                            return Some(icon);
-                        }
-                    }
-                    None
+                        })
+                    })
                 })
                 .or_else(|| {
                     for theme_base_dir in BASE_PATHS.iter() {


### PR DESCRIPTION
the spec says:  
> In at least one of the theme directories there must be a file called index.theme that describes the theme. The first index.theme found while searching the base directories in order is used. This file describes the general attributes of the theme.

I think it's probably reasonable to just use it as a fallback though, so we don't miss anything if a theme has a unique index.