### PR TITLE
fix/rfc(cache): if previously not found, still look up icon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,10 +227,7 @@ impl<'a> LookupBuilder<'a> {
                 CacheEntry::Found(icon) => {
                     return Some(icon);
                 }
-                CacheEntry::NotFound => {
-                    return None;
-                }
-                CacheEntry::Unknown => {}
+                _ => {}
             };
         }
 


### PR DESCRIPTION
Fixes: https://github.com/pop-os/libcosmic/issues/402

This fixes the case where an icon was previously looked up, not found, and now exists (i.e. when an application was installed)

This may not be desired behavior, it may be intended for icons that weren't found on initial cache lookup to be unreachable, hence why this is a fix/rfc.

An example in COSMIC for how the previous behavior can negatively affect applications on a taskbar:

![screenshot-2024-04-27-22-16-48](https://github.com/oknozor/freedesktop-icons/assets/56272643/ba11838f-d154-415e-a6a9-866a82977566)

The photo above shows how Visual Studio Code has a valid desktop entry and icon, but since the icon was installed shortly after the desktop entry, the icon is not accessible if we use the cache, since it looked it up and didn't find it at first.