### PR TITLE
fix: distance is not abs when getting closest size

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -72,7 +72,7 @@ impl Theme {
             .filter_map(|directory| {
                 let distance = directory.directory_size_distance(size, scale);
                 if distance < i16::MAX {
-                    Some((directory, distance))
+                    Some((directory, distance.abs()))
                 } else {
                     None
                 }


### PR DESCRIPTION
if not then it will be like: [-100, -9, 1, 22], and we get the first one which distance is -100