### PR TITLE
Try to load png and xmp in case svg is not found when force_svg is enabled

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -110,6 +110,8 @@ pub(super) fn try_build_icon_path<P: AsRef<Path>>(
 ) -> Option<PathBuf> {
     if force_svg {
         try_build_svg(name, path.as_ref())
+            .or_else(|| try_build_png(name, path.as_ref()))
+            .or_else(|| try_build_xmp(name, path.as_ref()))
     } else {
         try_build_png(name, path.as_ref())
             .or_else(|| try_build_svg(name, path.as_ref()))


### PR DESCRIPTION
In case force_svg is enabled, but the theme used does not have an svg icon for some icons, hicolor is being used instead of finding png icons. Lets fix this