### PR TITLE
Lookup with context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ pub struct LookupBuilder<'a> {
     scale: u16,
     size: u16,
     theme: &'a str,
+    context: Option<&'a str>,
 }
 
 /// Build an icon lookup for the given icon name.
@@ -225,6 +226,22 @@ impl<'a> LookupBuilder<'a> {
         self
     }
 
+    /// Restrict the lookup to the given conext.
+    ///
+    /// ## Example
+    /// ```rust
+    /// # fn main() {
+    /// use freedesktop_icons::lookup;
+    ///
+    /// let icon = lookup("firefox")
+    ///     .with_context("Applications")
+    ///     .find();
+    /// # }
+    pub fn with_context<'b: 'a>(mut self, context: &'b str) -> Self {
+        self.context = Some(context);
+        self
+    }
+
     /// Store the result of the lookup in cache, subsequent
     /// lookup will first try to get the cached icon.
     /// This can drastically increase lookup performances for application
@@ -279,6 +296,7 @@ impl<'a> LookupBuilder<'a> {
             scale: 1,
             size: 24,
             theme: "hicolor",
+            context: None,
         }
     }
 
@@ -301,7 +319,13 @@ impl<'a> LookupBuilder<'a> {
                 let icon = icon_themes
                     .iter()
                     .find_map(|theme| {
-                        theme.try_get_icon(self.name, self.size, self.scale, self.force_svg)
+                        theme.try_get_icon(
+                            self.name,
+                            self.size,
+                            self.scale,
+                            self.force_svg,
+                            self.context,
+                        )
                     })
                     .or_else(|| {
                         // Fallback to the parent themes recursively
@@ -320,7 +344,13 @@ impl<'a> LookupBuilder<'a> {
                         parents.into_iter().find_map(|parent| {
                             THEMES.get(&parent).and_then(|parent| {
                                 parent.iter().find_map(|t| {
-                                    t.try_get_icon(self.name, self.size, self.scale, self.force_svg)
+                                    t.try_get_icon(
+                                        self.name,
+                                        self.size,
+                                        self.scale,
+                                        self.force_svg,
+                                        self.context,
+                                    )
                                 })
                             })
                         })
@@ -328,7 +358,13 @@ impl<'a> LookupBuilder<'a> {
                     .or_else(|| {
                         THEMES.get("hicolor").and_then(|icon_themes| {
                             icon_themes.iter().find_map(|theme| {
-                                theme.try_get_icon(self.name, self.size, self.scale, self.force_svg)
+                                theme.try_get_icon(
+                                    self.name,
+                                    self.size,
+                                    self.scale,
+                                    self.force_svg,
+                                    self.context,
+                                )
                             })
                         })
                     })

--- a/src/theme/directories.rs
+++ b/src/theme/directories.rs
@@ -61,7 +61,7 @@ impl Directory<'_> {
 
     pub fn match_context(&self, context: Option<&str>) -> bool {
         // If either the directory's or lookup's context is not specified, ignore context matching
-        if self.context.is_none() {
+        if context.is_none() || self.context.is_none() {
             return true;
         }
         // If both contexts are specified, ensure they match

--- a/src/theme/directories.rs
+++ b/src/theme/directories.rs
@@ -3,6 +3,7 @@ pub struct Directory<'a> {
     pub name: &'a str,
     pub size: i16,
     pub scale: i16,
+    pub context: Option<&'a str>,
     pub type_: DirectoryType,
     pub maxsize: i16,
     pub minsize: i16,
@@ -56,6 +57,15 @@ impl Directory<'_> {
                 }
             }
         }
+    }
+
+    pub fn match_context(&self, context: Option<&str>) -> bool {
+        // If either the directory's or lookup's context is not specified, ignore context matching
+        if self.context.is_none() {
+            return true;
+        }
+        // If both contexts are specified, ensure they match
+        self.context == context
     }
 }
 

--- a/src/theme/parse.rs
+++ b/src/theme/parse.rs
@@ -47,7 +47,7 @@ impl Theme {
             let mut min_size = None;
             let mut threshold = None;
             let mut scale = None;
-            // let mut context = None;
+            let mut context = None;
             let mut dtype = DirectoryType::default();
 
             #[allow(clippy::while_let_on_iterator)]
@@ -61,7 +61,7 @@ impl Theme {
                         match key {
                             "Size" => size = str::parse(value).ok(),
                             "Scale" => scale = str::parse(value).ok(),
-                            // "Context" => context = Some(value),
+                            "Context" => context = Some(value),
                             "Type" => dtype = DirectoryType::from(value),
                             "MaxSize" => max_size = str::parse(value).ok(),
                             "MinSize" => min_size = str::parse(value).ok(),
@@ -91,7 +91,7 @@ impl Theme {
                             name,
                             size,
                             scale: scale.unwrap_or(1),
-                            // context,
+                            context,
                             type_: dtype,
                             maxsize: max_size.unwrap_or(size),
                             minsize: min_size.unwrap_or(size),


### PR DESCRIPTION
Allows restricting lookups based on icon context. The [icon theme I'm using](https://github.com/SylEleuth/gruvbox-plus-icon-pack/tree/master) has a bunch of different icons with the same name differentiated by a context, so I need this to get the correct icon.

A context is just a `&str`, although maybe it could be an enum with the variants from the [icon naming specification](https://specifications.freedesktop.org/icon-naming-spec/latest/)?

And it's an optional field since it's not required key in the spec. If a directory doesn't have a specified context, `directory.match_context(context)` returns true as if the contexts did match.